### PR TITLE
Fix: Use default Discord sounds when custom URLs are empty

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -437,6 +437,14 @@ function getSoundURL(settingKey: string) {
         return url;
     };
 
+    if (!url) {
+        const defaultFiles = soundFileMapping[settingKey];
+        if (defaultFiles && defaultFiles.length > 0) {
+            return `https://discordapp.com/assets/${defaultFiles[0]}`;
+        }
+        return "";
+    }
+
     const correctedURL = addHttpsIfMissing(url);
 
     if (correctedURL && isValidURL(correctedURL) && hasValidExtension(correctedURL)) {


### PR DESCRIPTION
Added fallback to default Discord sounds when custom sound URLs are left empty.

**Behavior Before the Change:**
- If a custom URL is empty, the corresponding sound does not play, leaving it muted.
- The user is required to provide a valid URL, otherwise no sound is played.

**Behavior After the Change:**
- If a custom URL is left empty, the plugin will revert to playing the default Discord sound (if available in `soundFileMapping`).
- If no default sound is mapped, the sound remains muted, maintaining the current fallback behavior.